### PR TITLE
feat:Wrap example under requestBody.value for /v1/streaming.create_token

### DIFF
--- a/src/libs/HeyGen/openapi.yaml
+++ b/src/libs/HeyGen/openapi.yaml
@@ -529,7 +529,8 @@ paths:
             schema:
               type: object
             examples:
-              streaming.create_token: { }
+              streaming.create_token:
+                value: { }
       responses:
         '200':
           description: ''


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the example for the streaming token creation request body to use a value-wrapped object, aligning with OpenAPI expectations.
  * Improves accuracy of the API reference, reducing confusion and potential integration errors when generating streaming tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->